### PR TITLE
remove cglm subproject

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "subprojects/cglm"]
-	path = subprojects/cglm
-	url = https://github.com/recp/cglm.git

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
 public_inc = include_directories('include')
 
 wayland_client_dep = dependency('wayland-client')
-cglm_dep = dependency('cglm', fallback : ['cglm', 'cglm_dep'])
+cglm_dep = dependency('cglm')
 
 subdir('include')
 subdir('protocol')


### PR DESCRIPTION
## https://github.com/gray-armor/zsurface/pull/9/commits/2c819c563fc651a9a31e0827c025563e1be4a9d1

To zigen branch

cglm をsubproject として扱うのをやめる。
zen 自体 cglm がシステムにインストールされてないとビルドできないので、zsurfaceもそのようにして問題ない。